### PR TITLE
Track simple_reddit_oauth as submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ ng-app/libs/
 static_files/
 dtr5/settings_secrets.py
 NOTES
-simple_reddit_oauth

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "simple_reddit_oauth"]
+	path = simple_reddit_oauth
+	url = https://github.com/C14L/simple_reddit_oauth.git


### PR DESCRIPTION
I spent more time than I'd like to admit looking for this before I stumbled across it on your profile :)

I don't see any reason not to track it along with the rest of the repo.
